### PR TITLE
fix license claims

### DIFF
--- a/Twilio/Twilio-CA-ESP-Sample/package.json
+++ b/Twilio/Twilio-CA-ESP-Sample/package.json
@@ -14,7 +14,7 @@
     "type": "git"
   },
   "author": "gcartier@br.ibm.com",
-  "license": "ISC",
+  "license": "EPL-2.0",
   "devDependencies": {
     "@types/config": "0.0.34",
     "@types/mustache": "^0.8.32",

--- a/use_cases/CI_pipeline/package.json
+++ b/use_cases/CI_pipeline/package.json
@@ -21,5 +21,5 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "EPL-2.0"
 }


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

This fix is to address issues found in OSS license scan: https://lfscanning.org/reports/omp/zowe-2020-01-23-50ae66fc-1eab-48f6-a018-04da1feb3a21.html

I'm not quite sure if we can change the license in `Twilio/Twilio-CA-ESP-Sample/package.json`. If it's not appropriate, could we remove the package from the SCM and reference to the user where to download?